### PR TITLE
Application view uses isActive instead of status for breadcrumb badge

### DIFF
--- a/src/app/mission-control/applications/applications-view/applications-view.component.html
+++ b/src/app/mission-control/applications/applications-view/applications-view.component.html
@@ -18,7 +18,8 @@
         parentUrl: 'mission-control/solutions/view'
       }
     ]"
-    [isActive]="application.isActive"
+    [badgeText]="application.status"
+    [badgeColorClass]="application.status === 'Active' ? '' : 'dark-grey'"
   >
   </app-breadcrumbs>
 </header>

--- a/src/app/mission-control/solutions/solutions-view/solutions-view.component.html
+++ b/src/app/mission-control/solutions/solutions-view/solutions-view.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-breadcrumbs [title]="solution.name" [isActive]="solution.isActive"> </app-breadcrumbs>
+  <app-breadcrumbs [title]="solution.name" [badgeText]="solution.isActive ? 'Active' : ''"> </app-breadcrumbs>
   <div class="solution-actions">
     <mat-chip *ngIf="solution.deploymentState; else notDeployedChip" [color]="deploymentStateColor" selected>{{
       getDeploymentMessage

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.html
@@ -20,4 +20,4 @@
     </a>
   </ng-template>
 </div>
-<div class="badge" *ngIf="isActive">Active</div>
+<div class="badge" [ngClass]="badgeColorClass ? badgeColorClass : ''" *ngIf="badgeText">{{ badgeText }}</div>

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.scss
@@ -38,6 +38,7 @@
       margin-right: 0.5rem;
     }
   }
+
   a {
     border-radius: 4px;
   }

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.scss
@@ -38,11 +38,15 @@
       margin-right: 0.5rem;
     }
   }
+  a {
+    border-radius: 4px;
+  }
 }
 
 p {
   margin-block-start: 0;
   margin-block-end: 0;
+  border-radius: 4px;
 }
 
 .badge {

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.ts
@@ -10,7 +10,8 @@ import { Router, UrlSegment, PRIMARY_OUTLET } from '@angular/router';
 export class BreadcrumbsComponent implements OnInit, OnChanges {
   @Input() cancelActive = false;
   @Input() steps: BreadcrumbStep[] = [];
-  @Input() isActive = false;
+  @Input() badgeText: string = null;
+  @Input() badgeColorClass: string = null;
   /**
    * title - should only be used if steps are not used. It is used to replace the default value of last step.
    */

--- a/src/styles/_badge.scss
+++ b/src/styles/_badge.scss
@@ -2,8 +2,9 @@
   border-radius: 0.2rem;
   background-color: var(--green);
   color: var(--white);
-  padding: 0.2rem 0.5rem;
-  font-size: 0.75rem;
+  padding: 0.4rem 0.5rem;
+  margin: auto;
+  font-size: 14px;
   line-height: 1.3;
 
   &.black {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Read, understand and follow the **[contribution guidelines](https://www.tranquilitybase.io/contribution-guidelines/)**
- [x] Tested UI/API integration with current master:
  - [x] Login
  - [x] "Create New Solution"
  - [x] "Provision New Activator"
  - [x] "Create New WAN VPN"
  - [x] Dev user is able to request access to a "Locked" Activator
  - [x] Admin user is able to "Grant Access", "Lock", "Deprecate" and "Undeprecate" an Activator


## PR Type
What kind of change does this PR introduce?

Please check the one that applies to this PR.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] TranquilityBase application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Badges shows as 'Active' even if an app is inactive.
Issue Number: #256 

## What is the new behavior?
Breadcrumbs parameter isActive was deleted. Breadcrumbs now accept a 'badgeText' for status text and 'badgeColorClass' referencing a color in _badges.css

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
