### PR TITLE
Issue 227 Breadcrumbs responsiveness refactor

### DIFF
--- a/src/app/mission-control/activator-store/activator-store-view/activator-store-view.component.html
+++ b/src/app/mission-control/activator-store/activator-store-view/activator-store-view.component.html
@@ -26,6 +26,7 @@
             name: selectedActivatorName
           }
         ]"
+        [visibleBreadcrumbsStartIndex]="2"
       ></app-breadcrumbs>
     </ng-template>
     <p

--- a/src/app/mission-control/applications/applications-create/applications-create.component.html
+++ b/src/app/mission-control/applications/applications-create/applications-create.component.html
@@ -33,6 +33,7 @@
           name: 'Application details'
         }
       ]"
+      [visibleBreadcrumbsStartIndex]="3"
     ></app-breadcrumbs>
   </ng-template>
 </header>

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.html
@@ -1,18 +1,36 @@
-<button class="cancel-btn" *ngIf="cancelActive">
-  <mat-icon class="app-cancel-icon">cancel</mat-icon>
-  Cancel
-</button>
-<div class="step" *ngFor="let step of steps; last as lastElement">
-  <div *ngIf="!step.link && !step.id; else link">
-    <p [ngStyle]="lastElement ? { 'font-weight': 'bold' } : {}" mat-menu-item>
-      {{ step.allCaps ? (step.name | uppercase) : (step.name | titlecase) }}
-    </p>
+<div *ngIf="visibleBreadcrumbsStartIndex !== 0">
+  <div class="arrow">
+    <button mat-button [matMenuTriggerFor]="breadcrumbsMenu">
+      <mat-icon>more_horiz</mat-icon>
+    </button>
   </div>
+  <mat-menu #breadcrumbsMenu="matMenu">
+    <div *ngFor="let step of steps | slice: 0:visibleBreadcrumbsStartIndex">
+      <button mat-menu-item *ngIf="!step.link && !step.id; else link">
+        {{ step.allCaps ? (step.name | uppercase) : (step.name | titlecase) }}
+      </button>
+
+      <ng-template #link>
+        <a mat-menu-item routerLink="{{ '//' + step.link }}" [queryParams]="{ id: step.id }">
+          {{ step.allCaps ? (step.name | uppercase) : (step.name | titlecase) }}
+        </a>
+      </ng-template>
+    </div>
+  </mat-menu>
+</div>
+
+<div
+  class="step"
+  *ngFor="let step of steps | slice: visibleBreadcrumbsStartIndex; last as lastElement; first as firstElement"
+>
+  <button *ngIf="!step.link && !step.id; else link" mat-button [ngStyle]="lastElement ? { 'font-weight': 'bold' } : {}">
+    {{ step.allCaps ? (step.name | uppercase) : (step.name | titlecase) }}
+  </button>
 
   <ng-template #link>
     <a
       [ngStyle]="lastElement ? { 'font-weight': 'bold' } : {}"
-      mat-menu-item
+      mat-button
       routerLink="{{ '//' + step.link }}"
       [queryParams]="{ id: step.id }"
     >

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.scss
@@ -1,33 +1,16 @@
 :host {
   display: flex;
   align-items: center;
-}
-
-.cancel-btn {
-  background-color: transparent;
-  border: none;
-  outline: none;
-  color: var(--primary-color);
-  font-family: SF Pro Display;
-  font-style: normal;
-  font-weight: 600;
-  font-size: 1rem;
-  cursor: pointer;
+  flex-wrap: wrap;
 }
 
 .step {
-  font-size: 1.25rem;
   display: flex;
   align-items: center;
-
-  &:first-of-type {
-    font-weight: 800;
-  }
 
   &:not(:first-of-type) {
     &::before {
       --arrow-width: 2px;
-
       content: '';
       display: block;
       transform: rotate(45deg);
@@ -40,11 +23,30 @@
   }
 }
 
-p {
-  margin-block-start: 0;
-  margin-block-end: 0;
+a,
+button {
+  font-size: 14px;
+  font-weight: normal;
+  padding: 0 8px;
+  min-width: auto;
 }
 
 .badge {
   margin: 0 0.5rem;
+}
+
+.arrow {
+  display: flex;
+  align-items: center;
+
+  &::after {
+    --arrow-width: 2px;
+    display: block;
+    transform: rotate(45deg);
+    width: 0.5em;
+    height: 0.5em;
+    border-top: var(--arrow-width) solid var(--primary-color);
+    border-right: var(--arrow-width) solid var(--primary-color);
+    margin-right: 0.5rem;
+  }
 }

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.scss
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.scss
@@ -21,14 +21,11 @@
       margin-right: 0.5rem;
     }
   }
-
-  a {
-    border-radius: 4px;
-  }
 }
 
 a,
 button {
+  border-radius: 4px;
   font-size: 14px;
   font-weight: normal;
   padding: 0 8px;
@@ -45,6 +42,7 @@ button {
 
   &::after {
     --arrow-width: 2px;
+
     display: block;
     transform: rotate(45deg);
     width: 0.5em;

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.ts
@@ -8,9 +8,9 @@ import { Router, UrlSegment, PRIMARY_OUTLET } from '@angular/router';
   styleUrls: ['./breadcrumbs.component.scss']
 })
 export class BreadcrumbsComponent implements OnInit, OnChanges {
-  @Input() cancelActive = false;
   @Input() steps: BreadcrumbStep[] = [];
   @Input() isActive = false;
+  @Input() visibleBreadcrumbsStartIndex: number = 0;
   /**
    * title - should only be used if steps are not used. It is used to replace the default value of last step.
    */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Read, understand and follow the **[contribution guidelines](https://www.tranquilitybase.io/contribution-guidelines/)**
- [x] Tested UI/API integration with current master:
  - [x] Login
  - [x] "Create New Solution"
  - [x] "Provision New Activator"
  - [x] "Create New WAN VPN"
  - [x] Dev user is able to request access to a "Locked" Activator
  - [x] Admin user is able to "Grant Access", "Lock", "Deprecate" and "Undeprecate" an Activator


## PR Type
What kind of change does this PR introduce?

Please check the one that applies to this PR.

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] TranquilityBase application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #227 


## What is the new behavior?
Breadcrumbs now wrap if screen is too short.
Also visibleBreadcrumbsStartIndex prperty was added to Breadcrumbs component. If set to value > 0 - then breadcrumb steps up to this index will be hidden under ellipsis. (See example of this in 'provisioning new activator' with selected solution)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
