### PR TITLE
Breadcrumbs refactor to use router.data

### DIFF
--- a/src/app/administration/administration.module.ts
+++ b/src/app/administration/administration.module.ts
@@ -17,7 +17,14 @@ const routes: Routes = [
       {
         path: 'landing-zone',
         loadChildren: () => import('./landing-zone/landing-zone.module').then(m => m.LandingZoneModule),
-        canActivate: [AdminGuardService]
+        canActivate: [AdminGuardService],
+        data: {
+          breadcrumbsSteps: [
+            {
+              name: 'Landing Zone'
+            }
+          ]
+        }
         // },
         // {
         //   path: 'shared-services',
@@ -29,7 +36,14 @@ const routes: Routes = [
       },
       {
         path: 'teams',
-        loadChildren: () => import('./teams/teams.module').then(m => m.TeamsModule)
+        loadChildren: () => import('./teams/teams.module').then(m => m.TeamsModule),
+        data: {
+          breadcrumbsSteps: [
+            {
+              name: 'Teams'
+            }
+          ]
+        }
         // },
         // {
         //   path: 'settings',
@@ -37,7 +51,14 @@ const routes: Routes = [
       },
       {
         path: 'users',
-        loadChildren: () => import('./users/users.module').then(m => m.UsersModule)
+        loadChildren: () => import('./users/users.module').then(m => m.UsersModule),
+        data: {
+          breadcrumbsSteps: [
+            {
+              name: 'Users'
+            }
+          ]
+        }
       }
     ]
   }

--- a/src/app/administration/landing-zone/landing-zone-environment/landing-zone-environment.module.ts
+++ b/src/app/administration/landing-zone/landing-zone-environment/landing-zone-environment.module.ts
@@ -36,6 +36,17 @@ const routes: Routes = [
       environmentListData: EnvironmentListDataResolver,
       folderStructureTreeData: FolderStructureTreeDataResolver,
       lanVPCListData: LanVPCListDataResolver
+    },
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Landing Zone',
+          link: '/administration/landing-zone'
+        },
+        {
+          name: 'Environment'
+        }
+      ]
     }
   }
 ];

--- a/src/app/administration/landing-zone/landing-zone-wan/landing-zone-wan-home/landing-zone-wan-home.component.html
+++ b/src/app/administration/landing-zone/landing-zone-wan/landing-zone-wan-home/landing-zone-wan-home.component.html
@@ -6,8 +6,7 @@
         link: '/administration/landing-zone'
       },
       {
-        name: 'WAN',
-        allCaps: true
+        name: 'WAN'
       }
     ]"
   ></app-breadcrumbs>

--- a/src/app/administration/teams/teams-create/teams-create.component.html
+++ b/src/app/administration/teams/teams-create/teams-create.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-breadcrumbs [title]="'Create new Team'"> </app-breadcrumbs>
+  <app-breadcrumbs> </app-breadcrumbs>
 </header>
 <main>
   <form [formGroup]="teamForm" (ngSubmit)="onSubmit(teamForm.value)">

--- a/src/app/administration/teams/teams-edit/teams-edit.component.html
+++ b/src/app/administration/teams/teams-edit/teams-edit.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-breadcrumbs [title]="'Edit team'"> </app-breadcrumbs>
+  <app-breadcrumbs> </app-breadcrumbs>
 </header>
 <main>
   <form [formGroup]="teamForm" (ngSubmit)="onSubmit(teamForm.value)">

--- a/src/app/administration/teams/teams-view/teams-view.component.html
+++ b/src/app/administration/teams/teams-view/teams-view.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-breadcrumbs [title]="'View team'"> </app-breadcrumbs>
+  <app-breadcrumbs> </app-breadcrumbs>
 </header>
 <main>
   <mat-tab-group mat-stretch-tabs>

--- a/src/app/administration/teams/teams.module.ts
+++ b/src/app/administration/teams/teams.module.ts
@@ -13,20 +13,64 @@ const routes: Routes = [
   },
   {
     path: 'create',
-    loadChildren: () => import('./teams-create/teams-create.module').then(m => m.TeamsCreateModule)
+    loadChildren: () => import('./teams-create/teams-create.module').then(m => m.TeamsCreateModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Teams',
+          link: '/administration/teams'
+        },
+        {
+          name: 'Create new Team'
+        }
+      ]
+    }
   },
   {
     path: 'edit',
-    loadChildren: () => import('./teams-edit/teams-edit.module').then(m => m.TeamsEditModule)
+    loadChildren: () => import('./teams-edit/teams-edit.module').then(m => m.TeamsEditModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Teams',
+          link: '/administration/teams'
+        },
+        {
+          name: 'Edit'
+        }
+      ]
+    }
   },
   {
     path: 'view',
-    loadChildren: () => import('./teams-view/teams-view.module').then(m => m.TeamsViewModule)
+    loadChildren: () => import('./teams-view/teams-view.module').then(m => m.TeamsViewModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Teams',
+          link: '/administration/teams'
+        },
+        {
+          name: 'View'
+        }
+      ]
+    }
   },
   {
     path: 'create-team-member',
     loadChildren: () =>
-      import('../team-members/team-members-create/team-members-create.module').then(m => m.TeamMembersCreateModule)
+      import('../team-members/team-members-create/team-members-create.module').then(m => m.TeamMembersCreateModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Teams',
+          link: '/administration/teams'
+        },
+        {
+          name: 'Create new team member'
+        }
+      ]
+    }
   }
 ];
 

--- a/src/app/administration/users/users-create/users-create.component.html
+++ b/src/app/administration/users/users-create/users-create.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-breadcrumbs [title]="'Create new user'"> </app-breadcrumbs>
+  <app-breadcrumbs> </app-breadcrumbs>
 </header>
 <main>
   <form [formGroup]="userForm" (ngSubmit)="onSubmit(userForm.value)">

--- a/src/app/administration/users/users-edit/users-edit.component.html
+++ b/src/app/administration/users/users-edit/users-edit.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-breadcrumbs [title]="'Edit'"> </app-breadcrumbs>
+  <app-breadcrumbs> </app-breadcrumbs>
 </header>
 <main>
   <form [formGroup]="userForm" (ngSubmit)="onSubmit(userForm.value)">

--- a/src/app/administration/users/users-view/users-view.component.html
+++ b/src/app/administration/users/users-view/users-view.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-breadcrumbs [title]="'View User'"> </app-breadcrumbs>
+  <app-breadcrumbs> </app-breadcrumbs>
 </header>
 
 <mat-card class="user-view-card">

--- a/src/app/administration/users/users.module.ts
+++ b/src/app/administration/users/users.module.ts
@@ -13,15 +13,48 @@ const routes: Routes = [
   },
   {
     path: 'create',
-    loadChildren: () => import('./users-create/users-create.module').then(m => m.UsersCreateModule)
+    loadChildren: () => import('./users-create/users-create.module').then(m => m.UsersCreateModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Users',
+          link: '/administration/users'
+        },
+        {
+          name: 'Create new user'
+        }
+      ]
+    }
   },
   {
     path: 'edit',
-    loadChildren: () => import('./users-edit/users-edit.module').then(m => m.UsersEditModule)
+    loadChildren: () => import('./users-edit/users-edit.module').then(m => m.UsersEditModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Users',
+          link: '/administration/users'
+        },
+        {
+          name: 'Edit'
+        }
+      ]
+    }
   },
   {
     path: 'view',
-    loadChildren: () => import('./users-view/users-view.module').then(m => m.UsersViewModule)
+    loadChildren: () => import('./users-view/users-view.module').then(m => m.UsersViewModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Users',
+          link: '/administration/users'
+        },
+        {
+          name: 'View'
+        }
+      ]
+    }
   }
 ];
 

--- a/src/app/mission-control/activator-store/activator-store-view/activator-store-view.component.html
+++ b/src/app/mission-control/activator-store/activator-store-view/activator-store-view.component.html
@@ -1,6 +1,17 @@
 <header class="activ-sub-header">
   <div class="header-left">
-    <app-breadcrumbs *ngIf="!(isSelectedSolution$ | async); else solutionSelectedBreadcrmbs" [title]="activator.name">
+    <app-breadcrumbs
+      *ngIf="!(isSelectedSolution$ | async); else solutionSelectedBreadcrmbs"
+      [steps]="[
+        {
+          name: 'Activator Store',
+          link: '/mission-control/activator-store'
+        },
+        {
+          name: selectedActivatorName
+        }
+      ]"
+    >
     </app-breadcrumbs>
     <ng-template #solutionSelectedBreadcrmbs>
       <app-breadcrumbs

--- a/src/app/mission-control/activator-store/activator-store.module.ts
+++ b/src/app/mission-control/activator-store/activator-store.module.ts
@@ -24,12 +24,30 @@ const routes: Routes = [
       {
         path: '',
         loadChildren: () =>
-          import('./activator-store-home/activator-store-home.module').then(m => m.ActivatorStoreHomeModule)
+          import('./activator-store-home/activator-store-home.module').then(m => m.ActivatorStoreHomeModule),
+        data: {
+          breadcrumbsSteps: [
+            {
+              name: 'Activator Store'
+            }
+          ]
+        }
       },
       {
         path: 'view',
         loadChildren: () =>
-          import('./activator-store-view/activator-store-view.module').then(m => m.ActivatorStoreViewModule)
+          import('./activator-store-view/activator-store-view.module').then(m => m.ActivatorStoreViewModule),
+        data: {
+          breadcrumbsSteps: [
+            {
+              name: 'Activator Store',
+              link: '/mission-control/activator-store'
+            },
+            {
+              name: 'View'
+            }
+          ]
+        }
       },
       {
         path: 'create-app',

--- a/src/app/mission-control/applications/applications-create/applications-create.component.html
+++ b/src/app/mission-control/applications/applications-create/applications-create.component.html
@@ -1,7 +1,15 @@
 <header>
   <app-breadcrumbs
     *ngIf="!(selectedSolution$ | async); else solutionSelectedBreadcrmbs"
-    [title]="selectedActivator.name"
+    [steps]="[
+      {
+        name: 'Activator Store',
+        link: '/mission-control/activator-store'
+      },
+      {
+        name: selectedActivator.name
+      }
+    ]"
   >
   </app-breadcrumbs>
   <ng-template #solutionSelectedBreadcrmbs>

--- a/src/app/mission-control/applications/applications-view/applications-view.component.html
+++ b/src/app/mission-control/applications/applications-view/applications-view.component.html
@@ -9,13 +9,11 @@
       {
         name: (solution$ | async) ? (solution$ | async).name : '',
         link: '/mission-control/solutions/view',
-        id: application ? application.solutionId : '',
-        parentUrl: 'mission-control/solutions'
+        id: application ? application.solutionId : ''
       },
       {
         link: '/mission-control/solutions/view',
-        name: application ? application.name : '',
-        parentUrl: 'mission-control/solutions/view'
+        name: application ? application.name : ''
       }
     ]"
     [badgeText]="application.status"

--- a/src/app/mission-control/solutions/solutions-create/solutions-create.component.html
+++ b/src/app/mission-control/solutions/solutions-create/solutions-create.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-breadcrumbs [title]="'Create new solution'"> </app-breadcrumbs>
+  <app-breadcrumbs> </app-breadcrumbs>
 </header>
 
 <mat-horizontal-stepper [linear]="true" #stepper>

--- a/src/app/mission-control/solutions/solutions-view/solutions-view.component.html
+++ b/src/app/mission-control/solutions/solutions-view/solutions-view.component.html
@@ -1,5 +1,16 @@
 <header>
-  <app-breadcrumbs [title]="solution.name" [badgeText]="solution.isActive ? 'Active' : ''"> </app-breadcrumbs>
+  <app-breadcrumbs
+    [steps]="[
+      {
+        name: 'Solutions',
+        link: '/mission-control/solutions'
+      },
+      {
+        name: solution.name
+      }
+    ]"
+    [badgeText]="solution.isActive ? 'Active' : ''"
+  ></app-breadcrumbs>
   <div class="solution-actions">
     <mat-chip *ngIf="solution.deploymentState; else notDeployedChip" [color]="deploymentStateColor" selected>{{
       getDeploymentMessage

--- a/src/app/mission-control/solutions/solutions.module.ts
+++ b/src/app/mission-control/solutions/solutions.module.ts
@@ -11,11 +11,29 @@ import { SharedModule } from '@app/shared/shared.module';
 const routes: Routes = [
   {
     path: '',
-    loadChildren: () => import('./solutions-home/solutions-home.module').then(m => m.SolutionsHomeModule)
+    loadChildren: () => import('./solutions-home/solutions-home.module').then(m => m.SolutionsHomeModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Solutions'
+        }
+      ]
+    }
   },
   {
     path: 'create',
-    loadChildren: () => import('./solutions-create/solutions-create.module').then(m => m.SolutionsCreateModule)
+    loadChildren: () => import('./solutions-create/solutions-create.module').then(m => m.SolutionsCreateModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Solutions',
+          link: '/mission-control/solutions'
+        },
+        {
+          name: 'Create new Solution'
+        }
+      ]
+    }
   },
   {
     path: 'edit',
@@ -23,7 +41,18 @@ const routes: Routes = [
   },
   {
     path: 'view',
-    loadChildren: () => import('./solutions-view/solutions-view.module').then(m => m.SolutionsViewModule)
+    loadChildren: () => import('./solutions-view/solutions-view.module').then(m => m.SolutionsViewModule),
+    data: {
+      breadcrumbsSteps: [
+        {
+          name: 'Solutions',
+          link: '/mission-control/solutions'
+        },
+        {
+          name: 'View'
+        }
+      ]
+    }
   }
 ];
 

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.html
@@ -5,7 +5,7 @@
 <div class="step" *ngFor="let step of steps; last as lastElement">
   <div *ngIf="!step.link && !step.id; else link">
     <p [ngStyle]="lastElement ? { 'font-weight': 'bold' } : {}" mat-menu-item>
-      {{ step.allCaps ? (step.name | uppercase) : (step.name | titlecase) }}
+      {{ step.name }}
     </p>
   </div>
 
@@ -16,7 +16,7 @@
       routerLink="{{ '//' + step.link }}"
       [queryParams]="{ id: step.id }"
     >
-      {{ step.allCaps ? (step.name | uppercase) : (step.name | titlecase) }}
+      {{ step.name }}
     </a>
   </ng-template>
 </div>

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.model.ts
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.model.ts
@@ -5,5 +5,4 @@ export interface BreadcrumbStep {
   name: string;
   link?: string;
   id?: string;
-  allCaps?: boolean;
 }

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.ts
@@ -1,66 +1,25 @@
-import { Component, Input, OnInit, OnChanges } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { BreadcrumbStep } from './breadcrumbs.component.model';
-import { Router, UrlSegment, PRIMARY_OUTLET } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-breadcrumbs',
   templateUrl: './breadcrumbs.component.html',
   styleUrls: ['./breadcrumbs.component.scss']
 })
-export class BreadcrumbsComponent implements OnInit, OnChanges {
+export class BreadcrumbsComponent implements OnInit {
   @Input() cancelActive = false;
   @Input() steps: BreadcrumbStep[] = [];
   @Input() badgeText: string = null;
   @Input() badgeColorClass: string = null;
-  /**
-   * title - should only be used if steps are not used. It is used to replace the default value of last step.
-   */
-  @Input() title = '';
 
-  private titleCurrent = '';
-  private isTitleUpdated = false;
-
-  constructor(private route: Router) {}
+  constructor(private route: ActivatedRoute) {}
 
   ngOnInit(): void {
-    /**
-     * If steps are not explicitly given in Input, read from url.
-     */
-    if (!this.steps.length || this.isTitleUpdated) {
-      let tree = this.route.parseUrl(location.pathname);
-      let segments = tree.root.children[PRIMARY_OUTLET].segments;
-      /**
-       * Skip first segment - it's not necessary, and provides invalid link.
-       */
-      let currentPath = segments.shift().path;
-      this.steps = this.steps.concat(
-        segments.map(
-          (segment: UrlSegment, index: number): BreadcrumbStep => {
-            currentPath += '/' + segment.path;
-            return {
-              name: segment.path.replace('-', ' '),
-              link: index !== segments.length - 1 ? currentPath : null // Set link if not last element
-            };
-          }
-        )
-      );
-      /**
-       * If title was updated synchronously (before onInit), move it to the last position.
-       */
-      if (this.isTitleUpdated) {
-        let titleStep = this.steps.shift();
-        this.steps.pop();
-        this.steps.push(titleStep);
-      }
-    }
-  }
-
-  ngOnChanges(): void {
-    if (this.title && (!this.isTitleUpdated || this.titleCurrent !== this.title)) {
-      this.steps.pop();
-      this.steps.push({ name: this.title });
-      this.titleCurrent = this.title;
-      this.isTitleUpdated = true;
+    if (!this.steps.length) {
+      this.route.data.subscribe(data => {
+        this.steps = data.breadcrumbsSteps;
+      });
     }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Read, understand and follow the **[contribution guidelines](https://www.tranquilitybase.io/contribution-guidelines/)**
- [x] Tested UI/API integration with current master:
  - [x] Login
  - [x] "Create New Solution"
  - [x] "Provision New Activator"
  - [x] "Create New WAN VPN"
  - [x] Dev user is able to request access to a "Locked" Activator
  - [x] Admin user is able to "Grant Access", "Lock", "Deprecate" and "Undeprecate" an Activator


## PR Type
What kind of change does this PR introduce?

Please check the one that applies to this PR.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] TranquilityBase application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #224 

## What is the new behavior?
Breadcrumbs use router.data if 'steps' aren't given through parameters.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
