### PR TITLE
Revert "Bump typescript from 3.9.7 to 4.0.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12668,9 +12668,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "pretty-quick": "~3.1.0",
     "protractor": "~7.0.0",
     "tslint": "~6.1.3",
-    "typescript": "^4.0.5"
+    "typescript": "^3.9.7"
   }
 }


### PR DESCRIPTION
Reverts tranquilitybase-io/tb-eagle-console#417

Build of a production ready version is failing with following message:
```sh
ERROR in The Angular Compiler requires TypeScript >=3.9.2 and <4.1.0 but 4.1.3 was found instead.
```